### PR TITLE
Add planning roadmap

### DIFF
--- a/logs/activity.log
+++ b/logs/activity.log
@@ -1,0 +1,4 @@
+## Sat Jul 12 17:00:21 UTC 2025
+Started Ticket 1 - Create Development Roadmap
+Marked Ticket 1 as started in tickets.md
+Created planning.md with development milestones

--- a/planning.md
+++ b/planning.md
@@ -1,0 +1,48 @@
+# Development Roadmap
+
+GenLoop will be developed in the following milestones derived from the design document. Each milestone contains a checklist of tasks to track progress.
+
+## Milestone 1: Project Initialization
+- [ ] Monorepo setup
+- [ ] README and folder scaffold
+- [ ] Installation docs
+
+## Milestone 2: CLI Core
+- [ ] `generate characters` command
+- [ ] `generate items` command
+- [ ] `generate environments` command
+- [ ] Workflow loading from `.json`
+- [ ] GenLoop node validation
+- [ ] CLI argument overrides
+- [ ] Run ComfyUI and watch for output
+- [ ] Debug and override flags
+
+## Milestone 3: Custom Nodes
+- [ ] `GenLoopInputNode` with prompt and metadata handling
+- [ ] Output nodes for characters, items and environments
+- [ ] PNG saving and metadata logging
+- [ ] Utility functions (slugifier, safe paths)
+
+## Milestone 4: GUI Application
+- [ ] Tabs for Characters, Items, Environments, Brainstorm and Style Sheet
+- [ ] Results view
+- [ ] Character slot management
+- [ ] GUI to CLI bridge with progress feedback
+
+## Milestone 5: Workflow Templates
+- [ ] Default character workflow
+- [ ] Default item workflow
+- [ ] Default environment workflow
+- [ ] Include GenLoop nodes in templates
+- [ ] Publish under `/workflows`
+
+## Milestone 6: Asset Metadata and Style Management
+- [ ] Style sheet collection
+- [ ] Slot memory for locked styles
+- [ ] Asset logs in JSON
+
+## Milestone 7: Packaging
+- [ ] PyInstaller build for CLI
+- [ ] GUI desktop packaging
+- [ ] Bundle default workflows and templates
+

--- a/tickets.md
+++ b/tickets.md
@@ -1,7 +1,7 @@
 # Tickets
 
 ## Ticket 1 - Create Development Roadmap
-- [ ] Started
+- [x] Started
 - [ ] Coded
 - [ ] Tested
 - [ ] Reviewed


### PR DESCRIPTION
## Summary
- start Ticket 1 on development roadmap
- create planning.md with milestones
- add activity log
- mark ticket as started

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687294602b6c8332a3093fbd7d776464