### PR TITLE
Implement item/environment commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ This repository is organised as a monorepo containing packages for the CLI, GUI,
 
 See [docs/installation.md](docs/installation.md) for setup instructions.
 
-For details on the command line interface, read [docs/cli.md](docs/cli.md). You can try the placeholder generation command:
+For details on the command line interface, read [docs/cli.md](docs/cli.md). You can try the placeholder generation commands:
 
 ```bash
 python -m genloop_cli generate characters
+python -m genloop_cli generate items
+python -m genloop_cli generate environments
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # CLI Usage
 
-GenLoop ships with a simple command line interface. It currently supports a `version` command and a placeholder command for generating character assets.
+GenLoop ships with a simple command line interface. It currently supports a `version` command and placeholder commands for generating character, item and environment assets.
 
 ```bash
 python -m genloop_cli version
@@ -10,6 +10,18 @@ To trigger character generation:
 
 ```bash
 python -m genloop_cli generate characters
+```
+
+To trigger item generation:
+
+```bash
+python -m genloop_cli generate items
+```
+
+To trigger environment generation:
+
+```bash
+python -m genloop_cli generate environments
 ```
 
 Future commands will include full asset generation functionality as described in `design.md`.

--- a/genloop_cli/cli.py
+++ b/genloop_cli/cli.py
@@ -22,5 +22,17 @@ def characters():
     """Generate character assets."""
     click.echo("Generating characters...")
 
+
+@generate.command()
+def items():
+    """Generate item assets."""
+    click.echo("Generating items...")
+
+
+@generate.command()
+def environments():
+    """Generate environment assets."""
+    click.echo("Generating environments...")
+
 if __name__ == "__main__":
     cli()

--- a/logs/activity.log
+++ b/logs/activity.log
@@ -16,3 +16,12 @@ Started Ticket 3 - Generate Characters Command
 Marked Ticket 3 as started in tickets.md
 Implemented generate characters command and tests
 Updated documentation for Ticket 3
+## Sat Jul 12 17:17:18 UTC 2025
+Started Ticket 4 - Generate Items Command
+Marked Ticket 4 as started in tickets.md
+Started Ticket 5 - Generate Environments Command
+Marked Ticket 5 as started in tickets.md
+Implemented generate items and environments commands with tests
+Updated documentation and README
+Marked generate characters command as done in planning.md
+Ran test suite

--- a/planning.md
+++ b/planning.md
@@ -8,7 +8,7 @@ GenLoop will be developed in the following milestones derived from the design do
 - [x] Installation docs
 
 ## Milestone 2: CLI Core
-- [ ] `generate characters` command
+- [x] `generate characters` command
 - [ ] `generate items` command
 - [ ] `generate environments` command
 - [ ] Workflow loading from `.json`

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,3 +12,15 @@ def test_generate_characters_command():
     result = subprocess.run([sys.executable, '-m', 'genloop_cli', 'generate', 'characters'], capture_output=True, text=True)
     assert result.returncode == 0
     assert 'Generating characters...' in result.stdout
+
+
+def test_generate_items_command():
+    result = subprocess.run([sys.executable, '-m', 'genloop_cli', 'generate', 'items'], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert 'Generating items...' in result.stdout
+
+
+def test_generate_environments_command():
+    result = subprocess.run([sys.executable, '-m', 'genloop_cli', 'generate', 'environments'], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert 'Generating environments...' in result.stdout

--- a/tickets.md
+++ b/tickets.md
@@ -31,3 +31,19 @@
 - [ ] Reviewed
 - [x] Documented
 - Implement the `generate characters` command in the CLI. For now it should simply output a message indicating that character generation has been triggered.
+
+## Ticket 4 - Generate Items Command
+- [x] Started
+- [x] Coded
+- [x] Tested
+- [ ] Reviewed
+- [x] Documented
+- Implement the `generate items` command in the CLI. It should output a message indicating that item generation has been triggered.
+
+## Ticket 5 - Generate Environments Command
+- [x] Started
+- [x] Coded
+- [x] Tested
+- [ ] Reviewed
+- [x] Documented
+- Implement the `generate environments` command in the CLI. It should output a message indicating that environment generation has been triggered.


### PR DESCRIPTION
## Summary
- add CLI commands for generating items and environments
- document new commands in README and docs
- mark character command complete in planning
- expand tests for new commands
- log development activities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68729824c4408332a0f6999e0e1c5a6c