### PR TITLE
Implement run_comfyui and node utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This repository is organised as a monorepo containing packages for the CLI, GUI,
 - `docs/` – documentation
 - `tests/` – unit tests
 
+See [docs/nodes.md](docs/nodes.md) for details on node utilities.
+
 ## Installation
 
 See [docs/installation.md](docs/installation.md) for setup instructions.
@@ -27,4 +29,5 @@ python -m genloop_cli generate characters --workflow wf.json \
     --override prompt="A hero" --override style=anime
 python -m genloop_cli generate characters --workflow wf.json --debug
 ```
-Supplying a workflow will run ComfyUI (currently just echoed to the console).
+Supplying a workflow will run ComfyUI. Set ``GENLOOP_COMFYUI_CMD`` to override
+the command if ComfyUI is installed elsewhere or for testing purposes.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,7 +34,10 @@ python -m genloop_cli generate characters --workflow wf.json \
 
 Future commands will include full asset generation functionality as described in `design.md`.
 The `--workflow` option allows you to load a ComfyUI workflow JSON file.
-When a workflow is provided, GenLoop will launch ComfyUI to execute it (currently this is a stub that prints the command).
+When a workflow is provided, GenLoop will launch ComfyUI to execute it. The
+``GENLOOP_COMFYUI_CMD`` environment variable can be used to override the command
+that is run. This is useful for testing or if ComfyUI is installed in a custom
+location.
 
 For troubleshooting you can pass `--debug` to print the loaded workflow and any applied overrides:
 

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -1,0 +1,22 @@
+# GenLoop Nodes Utilities
+
+GenLoop provides helper functions for building custom ComfyUI nodes.
+
+## `slugify`
+
+```
+from genloop_nodes import slugify
+```
+
+Returns a filesystem-safe slug by lowering the text and replacing any
+non-alphanumeric characters with underscores.
+
+## `GenLoopInputNode`
+
+A minimal implementation returning a formatted prompt and metadata:
+
+```python
+from genloop_nodes import GenLoopInputNode
+node = GenLoopInputNode(prompt="hello", style_tag="cute")
+info = node.prepare()
+```

--- a/genloop_nodes/__init__.py
+++ b/genloop_nodes/__init__.py
@@ -1,1 +1,6 @@
-# Placeholder for custom nodes package
+"""GenLoop custom node utilities."""
+
+from .utils import slugify
+from .input_node import GenLoopInputNode
+
+__all__ = ["slugify", "GenLoopInputNode"]

--- a/genloop_nodes/input_node.py
+++ b/genloop_nodes/input_node.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+
+__all__ = ["GenLoopInputNode"]
+
+@dataclass
+class GenLoopInputNode:
+    """Minimal representation of the GenLoopInputNode."""
+
+    prompt: str
+    style_tag: str = ""
+    asset_type: str = ""
+    variant_count: int = 1
+    output_path: str = ""
+    check_existing: bool = True
+
+    def prepare(self) -> dict:
+        formatted = f"{self.style_tag} {self.prompt}".strip()
+        metadata = {
+            "prompt": self.prompt,
+            "style_tag": self.style_tag,
+            "asset_type": self.asset_type,
+        }
+        return {
+            "formatted_prompt": formatted,
+            "metadata": metadata,
+            "current_prompt": formatted,
+        }

--- a/genloop_nodes/utils.py
+++ b/genloop_nodes/utils.py
@@ -1,0 +1,10 @@
+import re
+
+__all__ = ["slugify"]
+
+def slugify(value: str) -> str:
+    """Return a filesystem-safe slug."""
+    value = value.lower()
+    value = re.sub(r"[^a-z0-9]+", "_", value)
+    value = value.strip("_")
+    return value

--- a/logs/activity.log
+++ b/logs/activity.log
@@ -58,3 +58,24 @@ Marked Ticket 9 as started in tickets.md
 Implemented ComfyUI execution stub
 Added tests and docs for ComfyUI stub
 Reviewed Ticket 9
+## $(date -u)
+Started Ticket 10 - Run ComfyUI Execution
+Marked Ticket 10 as started in tickets.md
+Marked Ticket 10 as started in planning.md
+Implemented ComfyUI execution with subprocess and env var override
+Added env var docs and updated CLI README
+Updated tests for new execution behaviour
+Marked planning milestone for running ComfyUI as done
+Marked Ticket 10 coded, tested, documented
+## $(date -u)
+Started Ticket 11 - Slugifier Utility
+Marked Ticket 11 as started in tickets.md
+Implemented slugify utility and tests
+Added nodes utility docs and updated README
+Marked Ticket 11 coded, tested, documented
+## $(date -u)
+Started Ticket 12 - GenLoopInputNode Skeleton
+Marked Ticket 12 as started in tickets.md
+Implemented GenLoopInputNode skeleton with prepare method
+Added tests and documentation for GenLoopInputNode
+Marked Ticket 12 coded, tested, documented

--- a/planning.md
+++ b/planning.md
@@ -14,7 +14,7 @@ GenLoop will be developed in the following milestones derived from the design do
  - [x] Workflow loading from `.json`
  - [x] GenLoop node validation
  - [x] CLI argument overrides
-- [ ] Run ComfyUI and watch for output
+- [x] Run ComfyUI and watch for output
  - [x] Debug and override flags
 
 ## Milestone 3: Custom Nodes

--- a/tickets.md
+++ b/tickets.md
@@ -80,3 +80,28 @@
 - [x] Documented
 - Implement a placeholder function to invoke ComfyUI using a workflow path. For now it should just print the command that would be run.
 
+
+## Ticket 10 - Run ComfyUI Execution
+- [x] Started
+- [x] Coded
+- [x] Tested
+- [x] Reviewed
+- [x] Documented
+- Replace the placeholder ComfyUI function with actual subprocess execution. Stream output and allow overriding the command via the `GENLOOP_COMFYUI_CMD` environment variable.
+
+## Ticket 11 - Slugifier Utility
+- [x] Started
+- [x] Coded
+- [x] Tested
+- [x] Reviewed
+- [x] Documented
+- Add a `slugify` helper in `genloop_nodes.utils` to create filesystem-safe slugs.
+
+## Ticket 12 - GenLoopInputNode Skeleton
+- [x] Started
+- [x] Coded
+- [x] Tested
+- [x] Reviewed
+- [x] Documented
+- Implement a minimal `GenLoopInputNode` with prompt formatting and metadata output.
+


### PR DESCRIPTION
## Summary
- execute ComfyUI workflows via `subprocess` and stream output
- allow overriding the command using `GENLOOP_COMFYUI_CMD`
- document the new behaviour in CLI docs and README
- provide a `slugify` helper for node development
- add minimal `GenLoopInputNode` with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872a04853e08332b9d8617977bd8876