### PR TITLE
Implement safe_path and output nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ This repository is organised as a monorepo containing packages for the CLI, GUI,
 - `docs/` – documentation
 - `tests/` – unit tests
 
-See [docs/nodes.md](docs/nodes.md) for details on node utilities.
+See [docs/nodes.md](docs/nodes.md) for details on node utilities such as
+`GenLoopInputNode` and the output node classes that save generated assets.
 
 ## Installation
 

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -11,6 +11,15 @@ from genloop_nodes import slugify
 Returns a filesystem-safe slug by lowering the text and replacing any
 non-alphanumeric characters with underscores.
 
+## `safe_path`
+
+```
+from genloop_nodes import safe_path
+```
+
+Sanitises a path by replacing problematic characters. Useful when building
+file paths for generated assets.
+
 ## `GenLoopInputNode`
 
 A minimal implementation returning a formatted prompt and metadata:
@@ -19,4 +28,14 @@ A minimal implementation returning a formatted prompt and metadata:
 from genloop_nodes import GenLoopInputNode
 node = GenLoopInputNode(prompt="hello", style_tag="cute")
 info = node.prepare()
+```
+
+## `GenLoopOutput*Node`
+
+Output nodes save images and metadata to disk. Example usage:
+
+```python
+from genloop_nodes import GenLoopOutputCharacterNode
+node = GenLoopOutputCharacterNode(output_dir="out")
+node.save(b"img", {"prompt": "hi"}, name="hero")
 ```

--- a/genloop_nodes/__init__.py
+++ b/genloop_nodes/__init__.py
@@ -1,6 +1,17 @@
 """GenLoop custom node utilities."""
 
-from .utils import slugify
+from .utils import slugify, safe_path
 from .input_node import GenLoopInputNode
-
-__all__ = ["slugify", "GenLoopInputNode"]
+from .output_nodes import (
+    GenLoopOutputCharacterNode,
+    GenLoopOutputItemNode,
+    GenLoopOutputEnvironmentNode,
+)
+__all__ = [
+    "slugify",
+    "safe_path",
+    "GenLoopInputNode",
+    "GenLoopOutputCharacterNode",
+    "GenLoopOutputItemNode",
+    "GenLoopOutputEnvironmentNode",
+]

--- a/genloop_nodes/output_nodes.py
+++ b/genloop_nodes/output_nodes.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+import json
+import os
+from dataclasses import dataclass, field
+
+from .utils import safe_path
+
+__all__ = [
+    "GenLoopOutputNode",
+    "GenLoopOutputCharacterNode",
+    "GenLoopOutputItemNode",
+    "GenLoopOutputEnvironmentNode",
+]
+
+@dataclass
+class GenLoopOutputNode:
+    """Base class for GenLoop output nodes."""
+
+    output_dir: str = "outputs"
+    file_prefix: str = ""
+    asset_type: str = field(init=False, default="")
+
+    def _make_path(self, name: str) -> str:
+        name = safe_path(name)
+        os.makedirs(self.output_dir, exist_ok=True)
+        return os.path.join(self.output_dir, f"{self.file_prefix}{name}.png")
+
+    def save(self, image: bytes, metadata: dict, name: str = "output") -> str:
+        path = self._make_path(name)
+        with open(path, "wb") as f:
+            f.write(image)
+        with open(path + ".json", "w", encoding="utf-8") as f:
+            json.dump(metadata, f)
+        return path
+
+
+class GenLoopOutputCharacterNode(GenLoopOutputNode):
+    asset_type: str = "character"
+
+
+class GenLoopOutputItemNode(GenLoopOutputNode):
+    asset_type: str = "item"
+
+
+class GenLoopOutputEnvironmentNode(GenLoopOutputNode):
+    asset_type: str = "environment"

--- a/genloop_nodes/utils.py
+++ b/genloop_nodes/utils.py
@@ -1,6 +1,6 @@
 import re
 
-__all__ = ["slugify"]
+__all__ = ["slugify", "safe_path"]
 
 def slugify(value: str) -> str:
     """Return a filesystem-safe slug."""
@@ -8,3 +8,8 @@ def slugify(value: str) -> str:
     value = re.sub(r"[^a-z0-9]+", "_", value)
     value = value.strip("_")
     return value
+
+
+def safe_path(path: str) -> str:
+    """Return a path safe for file operations."""
+    return re.sub(r"[^a-zA-Z0-9_/.-]", "_", path)

--- a/logs/activity.log
+++ b/logs/activity.log
@@ -79,3 +79,14 @@ Marked Ticket 12 as started in tickets.md
 Implemented GenLoopInputNode skeleton with prepare method
 Added tests and documentation for GenLoopInputNode
 Marked Ticket 12 coded, tested, documented
+## $(date -u)
+Started Ticket 13 - Safe Path Utility
+Marked Ticket 13 as started in tickets.md
+Implemented safe_path utility with docs and tests
+Marked Ticket 13 coded, tested, documented and reviewed
+## $(date -u)
+Started Ticket 14 - GenLoopOutput Nodes
+Marked Ticket 14 as started in tickets.md
+Implemented output node classes with saving logic
+Updated docs, README and tests
+Marked Ticket 14 coded, tested, documented and reviewed

--- a/planning.md
+++ b/planning.md
@@ -18,10 +18,10 @@ GenLoop will be developed in the following milestones derived from the design do
  - [x] Debug and override flags
 
 ## Milestone 3: Custom Nodes
-- [ ] `GenLoopInputNode` with prompt and metadata handling
-- [ ] Output nodes for characters, items and environments
-- [ ] PNG saving and metadata logging
-- [ ] Utility functions (slugifier, safe paths)
+- [x] `GenLoopInputNode` with prompt and metadata handling
+- [x] Output nodes for characters, items and environments
+- [x] PNG saving and metadata logging
+- [x] Utility functions (slugifier, safe paths)
 
 ## Milestone 4: GUI Application
 - [ ] Tabs for Characters, Items, Environments, Brainstorm and Style Sheet

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,9 +128,20 @@ def test_slugify():
     assert slugify('Hello World!') == 'hello_world'
     assert slugify('Already_Slug') == 'already_slug'
 
+def test_safe_path():
+    from genloop_nodes.utils import safe_path
+    assert safe_path('path/to/My File.txt') == 'path/to/My_File.txt'
+
 def test_genloop_input_node_prepare():
     from genloop_nodes import GenLoopInputNode
     node = GenLoopInputNode(prompt='hello', style_tag='cute', asset_type='char')
     data = node.prepare()
     assert data['formatted_prompt'] == 'cute hello'
     assert data['metadata']['asset_type'] == 'char'
+
+def test_genloop_output_node_save(tmp_path):
+    from genloop_nodes import GenLoopOutputCharacterNode
+    node = GenLoopOutputCharacterNode(output_dir=tmp_path)
+    path = node.save(b'data', {'foo': 'bar'}, name='test')
+    assert (tmp_path / 'test.png').exists()
+    assert (tmp_path / 'test.png.json').exists()

--- a/tickets.md
+++ b/tickets.md
@@ -105,3 +105,19 @@
 - [x] Documented
 - Implement a minimal `GenLoopInputNode` with prompt formatting and metadata output.
 
+## Ticket 13 - Safe Path Utility
+- [x] Started
+- [x] Coded
+- [x] Tested
+- [x] Reviewed
+- [x] Documented
+- Implement a `safe_path` helper in `genloop_nodes.utils` to sanitise file paths.
+
+## Ticket 14 - GenLoopOutput Nodes
+- [x] Started
+- [x] Coded
+- [x] Tested
+- [x] Reviewed
+- [x] Documented
+- Add basic output node classes capable of saving PNG and JSON metadata using `safe_path`.
+


### PR DESCRIPTION
## Summary
- add `safe_path` util
- implement GenLoop output nodes
- document node usage
- update planning and tickets
- log development activity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872a34ab9b08332847c1b04bab8c114