### PR TITLE
Implement GUI results view and workflow templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This repository is organised as a monorepo containing packages for the CLI, GUI,
 ## Repository Structure
 
 - `genloop_cli/` – command line interface package
-- `genloop_gui/` – optional GUI package
+- `genloop_gui/` – optional GUI package with tabs for Characters, Items, Environments, Brainstorm, Style Sheet and a Results view listing generated files
 - `genloop_nodes/` – custom ComfyUI nodes
-- `workflows/` – default workflow templates
+- `workflows/` – default workflow templates (see [docs/workflows.md](docs/workflows.md))
 - `docs/` – documentation
 - `tests/` – unit tests
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,3 +44,4 @@ For troubleshooting you can pass `--debug` to print the loaded workflow and any 
 ```bash
 python -m genloop_cli generate characters --workflow wf.json --debug
 ```
+See [docs/workflows.md](workflows.md) for included templates.

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -17,4 +17,8 @@ The initial version exposes six tabs:
 - **Style Sheet**
 - **Results**
 
+The **Results** tab shows a list of generated image files from the
+``outputs`` directory. Use the refresh button to reload the list after
+running a generation command.
+
 Future versions will connect the GUI to the CLI to launch generation workflows and display progress.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,21 @@
+# Workflow Templates
+
+The `workflows/` directory contains example ComfyUI workflows ready to use with the CLI.
+
+## Character Workflow
+
+`character.json` includes a basic setup with `GenLoopInputNode` and `GenLoopOutputCharacterNode`.
+
+Use it with:
+
+```bash
+python -m genloop_cli generate characters --workflow workflows/character.json
+```
+
+## Item Workflow
+
+`item.json` is similar but outputs items using `GenLoopOutputItemNode`.
+
+## Environment Workflow
+
+`environment.json` outputs environments using `GenLoopOutputEnvironmentNode`.

--- a/genloop_gui/main.py
+++ b/genloop_gui/main.py
@@ -1,4 +1,36 @@
-from PySide6.QtWidgets import QApplication, QMainWindow, QTabWidget, QWidget
+import os
+from PySide6.QtWidgets import (
+    QApplication,
+    QMainWindow,
+    QTabWidget,
+    QWidget,
+    QListWidget,
+    QVBoxLayout,
+    QPushButton,
+)
+
+
+class ResultsWidget(QWidget):
+    """List files from the output directory."""
+
+    def __init__(self, output_dir: str = "outputs") -> None:
+        super().__init__()
+        self.output_dir = output_dir
+        self.list = QListWidget()
+        self.refresh_btn = QPushButton("Refresh")
+        self.refresh_btn.clicked.connect(self.refresh)
+        layout = QVBoxLayout()
+        layout.addWidget(self.list)
+        layout.addWidget(self.refresh_btn)
+        self.setLayout(layout)
+        self.refresh()
+
+    def refresh(self) -> None:
+        self.list.clear()
+        if os.path.isdir(self.output_dir):
+            for name in sorted(os.listdir(self.output_dir)):
+                if name.endswith(".png"):
+                    self.list.addItem(name)
 
 class MainWindow(QMainWindow):
     """Main window with tab widget."""
@@ -8,15 +40,16 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("GenLoop")
         self.tabs = QTabWidget()
         self.setCentralWidget(self.tabs)
-        for name in [
-            "Characters",
-            "Items",
-            "Environments",
-            "Brainstorm",
-            "Style Sheet",
-            "Results",
-        ]:
-            self.tabs.addTab(QWidget(), name)
+        tab_defs = [
+            ("Characters", QWidget()),
+            ("Items", QWidget()),
+            ("Environments", QWidget()),
+            ("Brainstorm", QWidget()),
+            ("Style Sheet", QWidget()),
+            ("Results", ResultsWidget()),
+        ]
+        for name, widget in tab_defs:
+            self.tabs.addTab(widget, name)
 
 def main():
     app = QApplication.instance() or QApplication([])

--- a/logs/activity.log
+++ b/logs/activity.log
@@ -100,3 +100,31 @@ Wrote unit test for MainWindow tabs
 Marked Ticket 15 coded and tested in tickets.md
 Marked planning milestone for GUI tabs as done
 Marked Ticket 15 documented and planning updated
+## $(date -u)
+Started Ticket 16 - GUI Results View
+Marked Ticket 16 as started in tickets.md
+Implemented ResultsWidget and updated GUI docs
+Added tests for results view
+Updated README and planning
+Marked Ticket 16 coded, tested, documented
+## $(date -u)
+Started Ticket 17 - Default Character Workflow
+Marked Ticket 17 as started in tickets.md
+Created workflows/character.json and documentation
+Added CLI link to workflow docs and README entry
+Wrote tests validating the default workflow
+Marked Ticket 17 coded, tested, documented
+## $(date -u)
+Started Ticket 18 - Default Item Workflow
+Marked Ticket 18 as started in tickets.md
+Created workflows/item.json and updated workflow docs
+Added tests validating item workflow
+Updated planning and tickets
+Marked Ticket 18 coded, tested, documented
+## $(date -u)
+Started Ticket 19 - Default Environment Workflow
+Marked Ticket 19 as started in tickets.md
+Created workflows/environment.json and updated docs
+Added tests for environment workflow
+Updated planning and tickets
+Marked Ticket 19 coded, tested, documented

--- a/planning.md
+++ b/planning.md
@@ -25,14 +25,14 @@ GenLoop will be developed in the following milestones derived from the design do
 
 ## Milestone 4: GUI Application
 - [x] Tabs for Characters, Items, Environments, Brainstorm and Style Sheet
-- [ ] Results view
+- [x] Results view
 - [ ] Character slot management
 - [ ] GUI to CLI bridge with progress feedback
 
 ## Milestone 5: Workflow Templates
-- [ ] Default character workflow
-- [ ] Default item workflow
-- [ ] Default environment workflow
+- [x] Default character workflow
+- [x] Default item workflow
+- [x] Default environment workflow
 - [ ] Include GenLoop nodes in templates
 - [ ] Publish under `/workflows`
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import subprocess
+from pathlib import Path
 import sys
 import os
 import json
@@ -145,3 +146,27 @@ def test_genloop_output_node_save(tmp_path):
     path = node.save(b'data', {'foo': 'bar'}, name='test')
     assert (tmp_path / 'test.png').exists()
     assert (tmp_path / 'test.png.json').exists()
+
+
+def test_default_character_workflow_valid():
+    wf_path = Path('workflows/character.json')
+    assert wf_path.exists()
+    from genloop_cli.workflow import load_workflow, validate_workflow
+    data = load_workflow(str(wf_path))
+    validate_workflow(data)
+
+
+def test_default_item_workflow_valid():
+    wf_path = Path('workflows/item.json')
+    assert wf_path.exists()
+    from genloop_cli.workflow import load_workflow, validate_workflow
+    data = load_workflow(str(wf_path))
+    validate_workflow(data)
+
+
+def test_default_environment_workflow_valid():
+    wf_path = Path('workflows/environment.json')
+    assert wf_path.exists()
+    from genloop_cli.workflow import load_workflow, validate_workflow
+    data = load_workflow(str(wf_path))
+    validate_workflow(data)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from genloop_gui import MainWindow
+from genloop_gui.main import ResultsWidget
 from PySide6.QtWidgets import QApplication
 
 
@@ -19,4 +20,16 @@ def test_main_window_tabs(monkeypatch):
     ]
     assert tabs == expected
     win.close()
+    app.quit()
+
+
+def test_results_widget_lists_pngs(tmp_path, monkeypatch):
+    monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
+    (tmp_path / "a.png").write_bytes(b"1")
+    (tmp_path / "b.png").write_bytes(b"2")
+    app = QApplication.instance() or QApplication([])
+    w = ResultsWidget(output_dir=tmp_path)
+    items = [w.list.item(i).text() for i in range(w.list.count())]
+    assert items == ["a.png", "b.png"]
+    w.close()
     app.quit()

--- a/tickets.md
+++ b/tickets.md
@@ -130,3 +130,35 @@
 - [x] Reviewed
 - [x] Documented
 - Implement a basic PySide6 GUI application with tabs for Characters, Items, Environments, Brainstorm, Style Sheet and Results. Provide a module entry point to launch the GUI.
+## Ticket 16 - GUI Results View
+- [x] Started
+- [x] Coded
+- [x] Tested
+- [x] Reviewed
+- [x] Documented
+- Implement a results view in the GUI that lists generated files from the output directory.
+
+## Ticket 17 - Default Character Workflow
+- [x] Started
+- [x] Coded
+- [x] Tested
+- [x] Reviewed
+- [x] Documented
+- Provide a default character workflow JSON under `workflows/` containing GenLoopInputNode and GenLoopOutputCharacterNode.
+
+## Ticket 18 - Default Item Workflow
+- [x] Started
+- [x] Coded
+- [x] Tested
+- [x] Reviewed
+- [x] Documented
+- Provide a default item workflow JSON under `workflows/` containing GenLoopInputNode and GenLoopOutputItemNode.
+
+## Ticket 19 - Default Environment Workflow
+- [x] Started
+- [x] Coded
+- [x] Tested
+- [x] Reviewed
+- [x] Documented
+- Provide a default environment workflow JSON under `workflows/` containing GenLoopInputNode and GenLoopOutputEnvironmentNode.
+

--- a/workflows/character.json
+++ b/workflows/character.json
@@ -1,0 +1,6 @@
+{
+  "nodes": [
+    {"id": 1, "type": "GenLoopInputNode"},
+    {"id": 2, "type": "GenLoopOutputCharacterNode"}
+  ]
+}

--- a/workflows/environment.json
+++ b/workflows/environment.json
@@ -1,0 +1,6 @@
+{
+  "nodes": [
+    {"id": 1, "type": "GenLoopInputNode"},
+    {"id": 2, "type": "GenLoopOutputEnvironmentNode"}
+  ]
+}

--- a/workflows/item.json
+++ b/workflows/item.json
@@ -1,0 +1,6 @@
+{
+  "nodes": [
+    {"id": 1, "type": "GenLoopInputNode"},
+    {"id": 2, "type": "GenLoopOutputItemNode"}
+  ]
+}


### PR DESCRIPTION
## Summary
- add ResultsWidget for listing generated PNG files
- mention results view in docs and README
- add default workflows for characters, items and environments
- document workflows and link from CLI docs
- validate default workflows in tests
- update planning and tickets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872a8ce39dc83329ec43710c52d382b