### PR TITLE
Code cleanup and flake8 fixes

### DIFF
--- a/genloop_cli/cli.py
+++ b/genloop_cli/cli.py
@@ -10,10 +10,12 @@ from .workflow import (
 )
 from .packaging import run_pyinstaller, bundle_workflows
 
+
 @click.group()
 def cli():
     """GenLoop command line interface."""
     pass
+
 
 @cli.command()
 def version():
@@ -29,7 +31,11 @@ def generate():
 
 @generate.command()
 @click.option("--workflow", type=click.Path(), help="Workflow JSON file")
-@click.option("--override", multiple=True, help="Override node value key=value")
+@click.option(
+    "--override",
+    multiple=True,
+    help="Override node key=value",
+)
 @click.option("--debug", is_flag=True, help="Show debug information")
 def characters(workflow, override, debug):
     """Generate character assets."""
@@ -46,7 +52,11 @@ def characters(workflow, override, debug):
 
 @generate.command()
 @click.option("--workflow", type=click.Path(), help="Workflow JSON file")
-@click.option("--override", multiple=True, help="Override node value key=value")
+@click.option(
+    "--override",
+    multiple=True,
+    help="Override node key=value",
+)
 @click.option("--debug", is_flag=True, help="Show debug information")
 def items(workflow, override, debug):
     """Generate item assets."""
@@ -63,7 +73,11 @@ def items(workflow, override, debug):
 
 @generate.command()
 @click.option("--workflow", type=click.Path(), help="Workflow JSON file")
-@click.option("--override", multiple=True, help="Override node value key=value")
+@click.option(
+    "--override",
+    multiple=True,
+    help="Override node key=value",
+)
 @click.option("--debug", is_flag=True, help="Show debug information")
 def environments(workflow, override, debug):
     """Generate environment assets."""
@@ -91,6 +105,7 @@ def package(target: str, dist: str) -> None:
         name = "genloop-gui"
     run_pyinstaller(entry, name, dist)
     bundle_workflows(dist)
+
 
 if __name__ == "__main__":
     cli()

--- a/genloop_cli/packaging.py
+++ b/genloop_cli/packaging.py
@@ -5,7 +5,6 @@ import subprocess
 from pathlib import Path
 import shutil
 import click
-from typing import Sequence
 
 __all__ = ["run_pyinstaller", "bundle_workflows"]
 

--- a/genloop_cli/workflow.py
+++ b/genloop_cli/workflow.py
@@ -61,7 +61,9 @@ def validate_workflow(data: dict) -> None:
     """Validate presence of required GenLoop nodes."""
     nodes = data.get("nodes", [])
     has_input = any(n.get("type") == "GenLoopInputNode" for n in nodes)
-    has_output = any(str(n.get("type", "")).startswith("GenLoopOutput") for n in nodes)
+    has_output = any(
+        str(n.get("type", "")).startswith("GenLoopOutput") for n in nodes
+    )
     if not (has_input and has_output):
         raise click.ClickException("Invalid workflow: missing GenLoop nodes")
 
@@ -71,7 +73,9 @@ def parse_overrides(values: tuple[str]) -> dict:
     overrides: dict[str, str] = {}
     for item in values:
         if '=' not in item:
-            raise click.ClickException(f"Invalid override '{item}' (expected key=value)")
+            raise click.ClickException(
+                f"Invalid override '{item}' (expected key=value)"
+            )
         key, value = item.split('=', 1)
         overrides[key] = value
     return overrides

--- a/genloop_gui/main.py
+++ b/genloop_gui/main.py
@@ -131,6 +131,7 @@ class CharacterTab(QWidget):
         self.memory.save()
         super().closeEvent(event)
 
+
 class MainWindow(QMainWindow):
     """Main window with tab widget."""
 
@@ -150,11 +151,13 @@ class MainWindow(QMainWindow):
         for name, widget in tab_defs:
             self.tabs.addTab(widget, name)
 
+
 def main():
     app = QApplication.instance() or QApplication([])
     win = MainWindow()
     win.show()
     app.exec()
+
 
 if __name__ == "__main__":
     main()

--- a/genloop_gui/style_sheet.py
+++ b/genloop_gui/style_sheet.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from typing import List
-from PySide6.QtWidgets import QWidget, QListWidget, QPushButton, QVBoxLayout, QListWidgetItem
+from PySide6.QtWidgets import (
+    QWidget,
+    QListWidget,
+    QPushButton,
+    QVBoxLayout,
+    QListWidgetItem,
+)
 from PySide6.QtCore import Qt
 
 
@@ -75,7 +81,9 @@ class StyleSheetTab(QWidget):
             self.list.takeItem(self.list.row(item))
 
     def closeEvent(self, event) -> None:  # type: ignore[override]
-        self.sheet.styles = [self.list.item(i).text() for i in range(self.list.count())]
+        self.sheet.styles = [
+            self.list.item(i).text()
+            for i in range(self.list.count())
+        ]
         self.sheet.save()
         super().closeEvent(event)
-

--- a/genloop_nodes/input_node.py
+++ b/genloop_nodes/input_node.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 
+
 __all__ = ["GenLoopInputNode"]
+
 
 @dataclass
 class GenLoopInputNode:

--- a/genloop_nodes/output_nodes.py
+++ b/genloop_nodes/output_nodes.py
@@ -13,6 +13,7 @@ __all__ = [
     "GenLoopOutputEnvironmentNode",
 ]
 
+
 @dataclass
 class GenLoopOutputNode:
     """Base class for GenLoop output nodes."""

--- a/genloop_nodes/utils.py
+++ b/genloop_nodes/utils.py
@@ -1,6 +1,8 @@
 import re
 
+
 __all__ = ["slugify", "safe_path"]
+
 
 def slugify(value: str) -> str:
     """Return a filesystem-safe slug."""

--- a/logs/activity.log
+++ b/logs/activity.log
@@ -167,3 +167,9 @@ Started Ticket 27 - Bundle Workflows
 Marked Ticket 27 as started in tickets.md
 Marked Milestone 7 packaging tasks as done
 Implemented packaging features and updated tickets 25-27
+## Sat Jul 12 19:38:21 UTC 2025
+Started Ticket 28 - Code Cleanup
+Marked Ticket 28 as started in tickets.md
+Ran flake8 and fixed style issues in CLI, nodes and GUI.
+Removed unused imports and ensured tests pass.
+Marked Ticket 28 coded, tested, documented

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import subprocess
 from genloop_gui import MainWindow
 from genloop_gui.main import ResultsWidget, CharacterTab

--- a/tickets.md
+++ b/tickets.md
@@ -224,3 +224,11 @@
 - [x] Reviewed
 - [x] Documented
 - Implement a helper that copies the contents of the `workflows` directory into a specified destination so packaged applications include the templates.
+
+## Ticket 28 - Code Cleanup
+- [x] Started
+- [x] Coded
+- [x] Tested
+- [x] Reviewed
+- [x] Documented
+- Address flake8 warnings, remove unused imports, and tidy files.


### PR DESCRIPTION
## Summary
- fix linting issues across CLI, nodes and GUI packages
- remove unused imports in GUI tests
- document progress in activity log
- create Ticket 28 for cleanup tasks

## Testing
- `pytest -q`
- `flake8 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6872b9208bf083329e3f972d8ea5f526